### PR TITLE
updated gap_fbh.R for issue #2

### DIFF
--- a/R/gap_fbh.R
+++ b/R/gap_fbh.R
@@ -90,6 +90,20 @@ get_gaps_fbhs<- function (LAD_profiles, step=1,
 
   df <- LAD_profiles
 
+  # check required columns exist in data and stop if not
+  nms_df <- sort(names(df))
+  nms_needed <- sort(c("treeID", "height", "lad"))
+  nms_miss <- nms_needed[!nms_needed %in% nms_df]
+  if(length(nms_miss)>0){
+    stop(paste(
+      "Columns not found in data. Supply missing columns:"
+      , paste(nms_miss, collapse = ", ")
+    ))
+  }
+
+  # reorder the columns so that it doesn't matter how the input data is structured
+  df <- df %>% dplyr::relocate(height, lad, treeID)
+
 
   if(min_height==0){
     min_height <-0.5
@@ -464,26 +478,22 @@ crown_lad <- data.frame(merged_crown2[2,])
    #######################################
 
    # Check if gaps6 exists and has data
-   if (!is.null(gaps6) && nrow(gaps6) > 0) {
-     gaps_height_t <- gaps6[1,] %>%
-       as.data.frame() %>%
-       dplyr::mutate_all(as.numeric) %>%
-       t() %>%
-       as.data.frame() %>%
-       dplyr::mutate(type = "gap")
+   if (!is.null(gaps5m) && nrow(gaps5m) > 0) {
+     gaps_height_t <- gaps5m %>%
+       dplyr::select(height) %>%
+       dplyr::mutate(type = "gap") %>%
+       dplyr::rename(V1=height)
    } else {
      gaps_height_t <- tibble(V1 = NA, type = "gap")
    }
 
 
    # Check if crown4 exists and contains data
-   if (!is.null(crown4) && nrow(crown4) > 0) {
-     crown_height_t <- crown4[1,] %>%
-       as.data.frame() %>%
-       dplyr::mutate_all(as.numeric) %>%
-       t() %>%
-       as.data.frame() %>%
-       dplyr::mutate(type = "cbh")
+   if (!is.null(crown3b) && nrow(crown3b) > 0) {
+     crown_height_t <- crown3b %>%
+       dplyr::select(height) %>%
+       dplyr::mutate(type = "cbh") %>%
+       dplyr::rename(V1=height)
    } else {
      crown_height_t <- tibble(V1 = NA, type = "cbh")
    }
@@ -527,6 +537,8 @@ names(max_height)="max_height"
     gap_cbh_metrics$treeID1 <- as.numeric(gap_cbh_metrics$treeID1)
     gap_cbh_metrics <- dplyr::arrange(gap_cbh_metrics, treeID1)
 
+    # make copy of treeID
+    df$treeID1 <- df$treeID
     treeID1<-unique(factor(df$treeID1))
 
     # Apply the code


### PR DESCRIPTION
Updated gap_fbh.R for issue #2. Added: 1) check for all column names needed in the `LAD_profiles` parameter; 2) reorder of columns so that input structure does not impact result; 3) specifically reference name of desired column to create data to pass to line that was initially causing issue.

Here is a test that shows the new updates working regardless of column order:

```
# data with treeID as first column
LAD_profile <- dplyr::tibble(
  treeID = rep(x = 1, times = 15)
  , height = seq(from = 1.5, to = 15.5, by = 1)
  , lad = c(
    0.568,0.606,0.338,0.143,0.170
    ,0.100,0.068,0.119,0.085,0.063
    ,0.034,0.021,0.005,0.007,0.001
  )
)
head(LAD_profile)
# get_gaps_fbhs() for data with treeID as first column
metrics_percentile <- LadderFuelsR::get_gaps_fbhs(LAD_profile, step=1, min_height=1.5)
# data with treeID as last column
LAD_profile2 <- LAD_profile[,c(2:3,1)]
# get_gaps_fbhs() for data with treeID as last column
metrics_percentile2 <- LadderFuelsR::get_gaps_fbhs(LAD_profile2, step=1, min_height=1.5)
# check that identical
identical(metrics_percentile, metrics_percentile2)
```